### PR TITLE
wpa_gui dont load interfaces

### DIFF
--- a/wpa_supplicant-2.4/wpa_supplicant/wpa_gui-qt4/wpa_gui.desktop
+++ b/wpa_supplicant-2.4/wpa_supplicant/wpa_gui-qt4/wpa_gui.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Name=wpa_gui
 Comment=Graphical user interface for wpa_supplicant
-Exec=wpa_gui
+Exec=bash -c 'pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY XDG_RUNTIME_DIR=/tmp wpa_gui;exec bash'
 Icon=wpa_gui
 GenericName=wpa_supplicant user interface
 Terminal=false


### PR DESCRIPTION
Command `wpa_gui` will not work for a normal user because don't have permission to view network interfaces ...
... then `pkexec wpa_gui` or `sudo wpa_gui` is a requirement

But Qt in a non-dev environment will give an error:
```console
user@linux:~$ pkexec wpa_gui
qt.qpa.xcb: could not connect to display 
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, xcb.

Aborted
```
Then we need set the `env` for Qt with the launcher command:
`bash -c 'pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY XDG_RUNTIME_DIR=/tmp wpa_gui;exec bash'`

`pkexec` without bash -c it wont work from menu lanchers because the `env`variables will not be resolved.